### PR TITLE
fix/line-hint-comment-correction-for-ch13

### DIFF
--- a/ch13/locks/mutex/mutex.go
+++ b/ch13/locks/mutex/mutex.go
@@ -14,7 +14,7 @@ func increment() {
 	mu.Lock()
 	defer mu.Unlock() // Lock 직후 Unlock을 defer로 호출
 	count++
-	// 만약 여기서 panic이 발생해도 17행에서 defer된 Unlock은 실행됨
+	// 만약 여기서 panic이 발생해도 15행에서 defer된 Unlock은 실행됨
 }
 
 func main() {


### PR DESCRIPTION
## :rocket: Changes

- Change the wrong comment line hint `17` to `15` at `ch13/locks/mutex/mutex.go`.